### PR TITLE
Tekstendring i felleskomponenten KonsulenthusCard.tsx

### DIFF
--- a/components/ui/KonsulenthusCard.tsx
+++ b/components/ui/KonsulenthusCard.tsx
@@ -25,7 +25,7 @@ export default function KonsulenthusCard({
 
           <div className="space-x-2 ">
             <small className="text-sm font-medium leading-none">
-              Har sagt opp:
+              Har sagt opp eller permittert:
             </small>
 
             {type.map((item, index) => (


### PR DESCRIPTION
Etter at formålet med konsulentkarma.no ble endret fra å omfatte selskaper som har kansellert til å omfatte selskaper som har kansellert/permittert så må felleskomponenten KonsulenthusCard.tsx oppdateres for å reflektere dette (ref. cc3d8c884d31deaa456820574ae6146857f93c33 )

Eksempelvis er "Experis Academy" lagt til listen, selv om kilden for dette sier:

> – De er permittert, ikke sagt opp.

Artikkel brukt som kilde for "Experis Academy":
https://www.kode24.no/artikkel/experis-academy-permitterer-18-utviklere-og-stanser-opptak-ma-ha-is-i-magen/81411879