### PR TITLE
Endret label/tag for SALT fra "permittering academy" til "nyutdannede"

### DIFF
--- a/data/konsulenthus.json
+++ b/data/konsulenthus.json
@@ -2,7 +2,7 @@
   {
     "arbeidsgiver": "SALT", 
     "dato_for_oppsigelse": "2024",
-    "type": ["permittering academy"],
+    "type": ["nyutdannede"],
     "links": [
     {
     "text": "Artikkel i kode24",


### PR DESCRIPTION
Siden SALT ikke permitterte noen ifølge artikkelen i kode24, de lovet studentene en jobb til kursdeltakere: https://www.kode24.no/artikkel/elever-raser-mot-salt-bootcamp-ville-ikke-lenger-love-dem-jobb/81497360